### PR TITLE
Set the path to adapalint via system.file

### DIFF
--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -1,6 +1,6 @@
 context("basics")
 
-adaptalint_path <- '.'
+adaptalint_path <- system.file(package = "adaptalint")
 filepath <- system.file('extdata', 'styles.R', package='adaptalint')
 
 test_that("exports are correct", {


### PR DESCRIPTION
In lintr 2.0.0 the previous path does not find a package, so returns
NULL and causes a failure. Using `system.file()` fixes the issue.

I am actually somewhat baffled how this was working at all in `R CMD check` in the old version of lintr, the tests are not run in a parent of the package during `R CMD check`, so the package would not have previously been found.